### PR TITLE
Implemented SSO for OpenMRS Helpdesk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+lib/sso-mockup.js
 conf.js
 conf.json
 node_modules

--- a/conf.example.json
+++ b/conf.example.json
@@ -4,6 +4,12 @@
     "discourse": {
       "secret": "1234567890abcdef",
       "returnURL": "http://talk.openmrs.org/session/sso_login?{{QUERY}}"
+    },
+    "deskcom": {
+        "apiKey": "Your API KEY to deskcom site",
+        "siteKey": "The site key, i.e., the subdomain of your site",
+        "maxMinute": "Max expire time measured by minute",
+        "returnURL": "https://help.openmrs.org/customer/authentication/multipass/callback?multipass={{MULTIPASS}}&signature={{SIGNATURE}}"
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -4,3 +4,4 @@ Common.module.sso = require('./lib/sso')
 
 // Load strategies
 require('./lib/discourse')
+require('./lib/deskcom')

--- a/lib/desk-multipass.js
+++ b/lib/desk-multipass.js
@@ -1,0 +1,108 @@
+var crypto = require('crypto');
+
+/**
+ * This module is modified from node-desk module, the usage is not changed.
+ * Desk.com multipass documentation http://dev.desk.com/docs/portal/multipass
+ */
+var Desk = function(siteKey, apiKey) {
+  var self = this;
+  var hash = {};
+
+  /**
+   * @param {String} value User ID
+   * @return {Object} self
+   */
+  this.uid = function(value) {
+    hash.uid = value + '';
+    return self;
+  };
+
+  /**
+   * @param {Date/String} value Expiration date (Date object or ISO8601 string)
+   * @return {Object} self
+   */
+  this.expires = function(value) {
+    hash.expires = (value instanceof Date) ? value.toJSON() : value;
+    return self;
+  };
+
+  /**
+   * @param {String} value Customer email
+   * @return {Object} self
+   */
+  this.customer_email = function(value) {
+    hash.customer_email = value;
+    return self;
+  };
+
+  /**
+   * @param {String} value Customer name
+   * @return {Object} self
+   */
+  this.customer_name = function(value) {
+    hash.customer_name = value + '';
+    return self;
+  };
+
+  /**
+   * @param  {String} value Absolute URL
+   * @return {Object} self
+   */
+  this.to = function(value) {
+    hash.to = value + '';
+    return self;
+  };
+
+  /**
+   * @param {String} key unique custom name
+   * @param {String} value key value
+   * @return {Object} self
+   */
+  this.customer_custom = function(key, value) {
+    hash['customer_custom_' + key] = value;
+    return self;
+  };
+
+  /**
+   * @param {Function} callback function(error, multipass, signature)
+   */
+  this.end = function(callback) {
+    if (!(hash.uid && hash.expires && hash.customer_email && hash.customer_name))
+      return callback(new Error('Missing required field'));
+
+    // multipass
+    var key = crypto.createHash('sha1').update(apiKey + siteKey).digest('binary').substring(0, 16);
+    var iv = new Buffer('OpenSSL for Node', 'binary');
+    var data = new Buffer(JSON.stringify(hash));
+    var cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
+
+    // node crypto does autopadding by default
+    var multipass = cipher.update(data, 'binary', 'binary') + cipher.final('binary');
+
+    //prepend the iv
+    multipass = new Buffer(iv+multipass, 'binary');
+    multipass = multipass.toString('base64');
+
+    multipass = multipass
+      .replace(/\n/g, '') // remove new lines
+      .replace(/\=+$/, '') // remove trailing "="
+      .replace(/\+/g, '-') // "+" to "-"
+      .replace(/\//g, '_'); // "/" to "_"
+
+    // signature
+    var signature = crypto.createHmac('sha1', apiKey)
+      .update(multipass)
+      .digest('base64');
+
+    callback(null, multipass, encodeURIComponent(signature));
+  };
+};
+
+/**
+ * @param {String} siteKey Desk.com account/site key
+ * @param {String} apiKey Desk.com API key
+ * @return {Object} Desk object
+ */
+exports.createDesk = function(siteKey, apiKey) {
+  return new Desk(siteKey, apiKey);
+};

--- a/lib/deskcom.js
+++ b/lib/deskcom.js
@@ -1,0 +1,31 @@
+var sso = require('./sso'),
+    Desk = require('./desk-multipass'),
+    Common = require(global.__commonModule),
+    u = Common.conf.user,
+    conf = sso.conf.strategies.deskcom,
+    duration = conf.maxMinute*60*1000,
+    desk = Desk.createDesk(conf.siteKey, conf.apiKey);
+
+sso.register({
+  name: 'Deskcom',
+  serviceName: 'Openmrs Help',
+  id: 'deskcom',
+
+  validator: function(req, user) {
+    var expires = new Date();
+    expires.setTime(expires.getTime()+duration);
+
+    var ret;
+    desk.uid(user[u.username])
+      .expires(expires)
+      .customer_email(user[u.email])
+      .customer_name(user[u.displayname])
+      .end(function (err, multipass, signature) {
+        if (err) {
+          return ;
+        }
+        ret = conf.returnURL.replace('{{MULTIPASS}}',multipass).replace('{{SIGNATURE}}',signature);
+      });
+    return ret || false;
+  }
+})

--- a/lib/sso.js
+++ b/lib/sso.js
@@ -22,7 +22,7 @@ module.exports = {
       var loginString = strategy.validator(req, req.session.user)
 
       if (!loginString) {
-        return next(new Error('Unable to process Discourse login string'))
+        return next(new Error('Unable to process ' + strategy.id + ' login string'))
       }
 
       console.log('LOGIN STRING', loginString)
@@ -34,8 +34,9 @@ module.exports = {
       req.flash('info', 'Log in with your OpenMRS ID to access ' +
         strategy.serviceName)
 
+      var search = route.search || ''; // Avoid undefined
       return res.redirect('/login?destination=' +
-        encodeURIComponent(route.pathname + route.search))
+        encodeURIComponent(route.pathname + search));
     }
   },
 


### PR DESCRIPTION
Here is the implementation of SSO for OpenMRS Helpdesk.
1. As there is some issues about creating accounts of my local code, I used a mockup sso.js. I just modified the part of `authenticate`, here it goes.
   
   ```
   authenticate: function authenticate(req, res, next, strategy) {
   var route = url.parse(req.url)
   
   if (global.__mockupUser) { // Forward to endpoint
   
     var loginString = strategy.validator(req, global.__mockupUser);
   
     console.log('LOGIN STRING', loginString)
   
     res.redirect(loginString)
   
   } else { // Log in the user
   
     var user = {};
     user[u.username] = "Tom";
     user[u.email]    = "foo@bar.com";
     user[u.displayname] = "John Doe";
     global.__mockupUser = user;
   
     return res.redirect(route.pathname);
   }
   },
   ```
2. Usage
   Using Multipass
   **Enable It**
   1. For deskcom site
      - Log in to the Desk.com Administrator and go to “Support Center” on the “Channels” tab.
      - Select “Private Access” and select “Multipass” from “Authentication Method”
      - Set the Login URL as `https://%HOSTNAME%/login/authenticate/deskcom
      - Additionaly you can enable logout, by setting Logout URL as an arbitray one that you want users to be redirected to
      - Check `Require HMAC` and `Random IV`
      - Generate a Multipass Key, if you don't have one  
        Click “Update”
   2. For conf.json
      See conf.example.json, change `apiKey`, `siteKey` and `maxMinute` to meet your disire.
      Specifically, the `siteKey` is the subdomain of your deskcom site. e.g. If your site's domain is `tom.desk.com` then the siteKey will be `tom`
