### PR TITLE
Adaption to Dashboard 2.1 and Cipher Algo Updating

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
-var Common = require(global.__commonModule)
+'use strict';
 
-Common.module.sso = require('./lib/sso')
+exports = module.exports = function (app) {
+  // Load strategies
+  require('./lib/discourse')(app);
+  require('./lib/deskcom')(app);
+  require('./lib/atlas')(app);
+};
 
-// Load strategies
-require('./lib/discourse')
-require('./lib/deskcom')
-require('./lib/atlas')

--- a/lib/atlas-multipass.js
+++ b/lib/atlas-multipass.js
@@ -1,3 +1,7 @@
+'use strict';
+// TODO
+// Merge this with desk-multipass
+// It's basically a copy of that one
 var crypto = require('crypto');
 
 /**

--- a/lib/atlas.js
+++ b/lib/atlas.js
@@ -1,10 +1,14 @@
+'use strict';
 var sso = require('./sso');
 var Atlas = require('./atlas-multipass');
 var conf = sso.conf.strategies.atlas;
 var duration = conf.maxMinute*60*1000;
 var atlas = Atlas.createAtlas(conf.siteKey, conf.apiKey);
 
-sso.register({
+exports = module.exports = function (app) {
+
+
+sso.register(app, {
   name: 'Atlas',
   serviceName: 'OpenMRS Atlas',
   id: 'atlas',
@@ -26,4 +30,8 @@ sso.register({
       });
     return ret || false;
   }
-})
+});
+
+
+};
+

--- a/lib/desk-multipass.js
+++ b/lib/desk-multipass.js
@@ -1,3 +1,4 @@
+'use strict';
 var crypto = require('crypto');
 
 /**

--- a/lib/desk-multipass.js
+++ b/lib/desk-multipass.js
@@ -1,5 +1,5 @@
 'use strict';
-var crypto = require('crypto');
+var multi = require('./multipass');
 
 /**
  * This module is modified from node-desk module, the usage is not changed.
@@ -68,34 +68,15 @@ var Desk = function(siteKey, apiKey) {
    * @param {Function} callback function(error, multipass, signature)
    */
   this.end = function(callback) {
-    if (!(hash.uid && hash.expires && hash.customer_email && hash.customer_name))
+    if (!(hash.uid && hash.expires && hash.customer_email &&
+          hash.customer_name)) {
+
       return callback(new Error('Missing required field'));
-
-    // multipass
-    var key = crypto.createHash('sha1').update(apiKey + siteKey).digest('binary').substring(0, 16);
-    var iv = new Buffer('OpenSSL for Node', 'binary');
+    }
     var data = new Buffer(JSON.stringify(hash));
-    var cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
-
-    // node crypto does autopadding by default
-    var multipass = cipher.update(data, 'binary', 'binary') + cipher.final('binary');
-
-    //prepend the iv
-    multipass = new Buffer(iv+multipass, 'binary');
-    multipass = multipass.toString('base64');
-
-    multipass = multipass
-      .replace(/\n/g, '') // remove new lines
-      .replace(/\=+$/, '') // remove trailing "="
-      .replace(/\+/g, '-') // "+" to "-"
-      .replace(/\//g, '_'); // "/" to "_"
-
-    // signature
-    var signature = crypto.createHmac('sha1', apiKey)
-      .update(multipass)
-      .digest('base64');
-
-    callback(null, multipass, encodeURIComponent(signature));
+    var tmp = multi(data, apiKey, siteKey);
+    callback(null, encodeURIComponent(tmp.multipass),
+      encodeURIComponent(tmp.signature));
   };
 };
 

--- a/lib/deskcom.js
+++ b/lib/deskcom.js
@@ -1,10 +1,14 @@
+'use strict';
 var sso = require('./sso');
 var Desk = require('./desk-multipass');
 var conf = sso.conf.strategies.deskcom;
 var duration = conf.maxMinute*60*1000;
 var desk = Desk.createDesk(conf.siteKey, conf.apiKey);
 
-sso.register({
+exports = module.exports = function (app) {
+
+
+sso.register(app, {
   name: 'Deskcom',
   serviceName: 'OpenMRS Help Desk',
   id: 'deskcom',
@@ -28,3 +32,6 @@ sso.register({
     return ret || false;
   }
 });
+
+
+};

--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -1,13 +1,16 @@
+'use strict';
 var discourse_sso = require('discourse-sso');
 var path = require('path');
 var url = require('url');
 var request = require('request');
 var sso = require('./sso');
-var User = require(path.join(global.__apppath, 'model/user'));
-var log = require(path.join(global.__apppath, 'logger')).add('discourse-sso');
+var User = require('../../../models/user');
+var log = require('log4js').addLogger('discourse-sso');
 
 var conf = sso.conf.strategies.discourse;
 var discourse = new discourse_sso(conf.secret);
+
+exports = module.exports = function (app) {
 
 
 var buildURL = function (payload, sig, user) {
@@ -29,7 +32,7 @@ var buildURL = function (payload, sig, user) {
   return ret;
 };
 
-sso.register({
+sso.register(app, {
   name: 'Discourse',
   serviceName: 'OpenMRS Talk',
   id: 'discourse',
@@ -64,7 +67,7 @@ var syncUser = function (user, callback) {
         return callback(err);
       }
       return callback(null, res.statusCode === 200);
-    }).setMaxListeners(0)
+    }).setMaxListeners(0);
   }).setMaxListeners(0);
 };
 
@@ -86,4 +89,7 @@ User.schema.post('save', function (user) {
   });
 });
 
-exports.buildURL = buildURL;
+
+};
+
+

--- a/lib/multipass.js
+++ b/lib/multipass.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var crypto = require('crypto');
+
+/**
+ * build a multipass string and its signature in deskcom's preferences
+ * http://dev.desk.com/guides/sso/
+ * @param  {String}     data
+ * @param  {String}     apiKey
+ * @param  {String}     siteKey
+ * @return {Object}     {multipass, signature} base64 encoded
+ */
+function build (data, apiKey, siteKey) {
+    var key = crypto.createHash('sha1')
+                    .update(apiKey + siteKey)
+                    .digest('binary').substring(0, 16);
+    var iv = crypto.randomBytes(16);
+    var cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
+
+    var buffers = [];
+    buffers.push(iv);
+    buffers.push(cipher.update(data, 'utf8', 'buffer'));
+    buffers.push(cipher.final('buffer'));
+    var multipass = Buffer.concat(buffers).toString('base64');
+
+    // signature
+    var signature = crypto.createHmac('sha1', apiKey)
+      .update(multipass)
+      .digest('base64');
+
+      return {multipass: multipass, signature: signature};
+}
+
+exports = module.exports = build;

--- a/lib/sso.js
+++ b/lib/sso.js
@@ -1,6 +1,5 @@
-var Common = require(global.__commonModule);
-var app = Common.app;
-var _ = require('underscore');
+'use strict';
+var _ = require('lodash');
 var url = require('url');
 
 module.exports = {
@@ -56,7 +55,7 @@ module.exports = {
   //     name: human-readable name of the strategy (Discourse SSO)
   //     serviceName: name of the service using this strategy (OpenMRS Talk)
   //     validator: function that returns a processed login string
-  register: function register(opts) {
+  register: function register(app, opts) {
 
     var strategy = {
       id: opts.id,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/elliottwilliams/openmrs-contrib-id-sso/issues"
   },
   "dependencies": {
-    "discourse-sso": "~1.0.0",
-    "underscore": "~1.6.0"
+    "discourse-sso": "~1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sso authentication strategies for openmrs id",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha tests"
   },
   "repository": {
     "type": "git",

--- a/tests/multipass.js
+++ b/tests/multipass.js
@@ -1,0 +1,42 @@
+'use strict';
+/*jshint expr: true*/
+var crypto = require('crypto');
+var multi = require('../lib/multipass');
+var expect = require('chai').expect;
+
+
+// Testing data
+var apiKey = 'whitewizard';
+var siteKey = 'gandalf';
+var data = {'foo': 'bar', 'woo': 'hoo'};
+
+var crack = function (multipass, signature) {
+  var checkSignature = crypto.createHmac('sha1', apiKey)
+                             .update(multipass)
+                             .digest('base64');
+  if (signature !== checkSignature) {
+    return false;
+  }
+
+  var tmp = new Buffer(multipass, 'base64');
+  var iv = tmp.slice(0, 16);
+  multipass = tmp.slice(16);
+  var key = crypto.createHash('sha1')
+                  .update(apiKey + siteKey)
+                  .digest('binary').substring(0, 16);
+
+  var decipher = crypto.createDecipheriv('aes-128-cbc', key, iv);
+  var result = decipher.update(multipass, 'buffer', 'utf8');
+  result += decipher.final('utf8');
+  return result;
+};
+
+describe('multipass encrypting', function () {
+  it ('should correctly encode the info', function (done) {
+    var tdata = JSON.stringify(data);
+    var tmp = multi(tdata, apiKey, siteKey);
+    tmp = crack(tmp.multipass, tmp.signature);
+    expect(tmp).to.equal(tdata);
+    done();
+  });
+});


### PR DESCRIPTION
Now this module receives `app` via function parameters.

And during testing, I've found out that I've used a static iv in the multipass cipher algorithm last year...Sorry for this, it's my first work that time. Anyway, I've fixed this issue and added a test for multipass encrypting. Run it via `npm test`.

And also I've registered a temporary site for testing purpose [here](https://plypy.desk.com/), which is configured to redirect to `localhost:3000` for SSO authentication. You may try it your own.

What's more, last year @alexisduque  has derived another multipass solution for Atlas from my naive version... But I've left Atlas related sources unchanged since I don't how atlas verifies the multipass, so Alexis please update `atlas-multipass.js` like what I did to `desk-multipass.js`.